### PR TITLE
Update /PUT services of providers

### DIFF
--- a/Server/Controllers/ProvidersControllers/modifyProviderServices.js
+++ b/Server/Controllers/ProvidersControllers/modifyProviderServices.js
@@ -1,0 +1,31 @@
+const Provider = require('./../../Models/provider')
+
+const modifyProviderServices = async (services, id) => {
+    try {
+        let updatedServices = [...services]
+
+        const provider = await Provider.findById(id)
+
+        if (provider.services.length) {
+            provider.services.forEach((service) => {
+                const found = services.find(
+                    (addedService) => addedService.name === service.name
+                )
+                !found && updatedServices.push(service)
+            })
+        }
+
+        const updatedProvider = await Provider.updateOne(
+            { _id: id },
+            { services: updatedServices }
+        )
+
+        if (!updatedProvider.modifiedCount) throw new Error('sin cambios')
+
+        return updatedProvider
+    } catch (error) {
+        return error
+    }
+}
+
+module.exports = modifyProviderServices

--- a/Server/Handlers/ProvidersHandlers/updateOfferedServices.js
+++ b/Server/Handlers/ProvidersHandlers/updateOfferedServices.js
@@ -1,0 +1,17 @@
+const modifyProviderServices = require('./../../Controllers/ProvidersControllers/modifyProviderServices')
+
+const updateOfferedServices = async (req, res) => {
+    const { services, id } = req.body
+    try {
+        const updatedProvider = await modifyProviderServices(services, id)
+
+        if (updatedProvider.message === 'sin cambios')
+            throw new Error('No se realizaron cambios en los servicios')
+
+        res.status(200).json('Servicios vinculados')
+    } catch (error) {
+        res.status(400).json({ error: error.message })
+    }
+}
+
+module.exports = updateOfferedServices

--- a/Server/Handlers/ProvidersHandlers/updateOfferedServices.js
+++ b/Server/Handlers/ProvidersHandlers/updateOfferedServices.js
@@ -8,6 +8,8 @@ const updateOfferedServices = async (req, res) => {
         if (updatedProvider.message === 'sin cambios')
             throw new Error('No se realizaron cambios en los servicios')
 
+        // Agregar controller que updatea servicios cuando esté creado
+
         res.status(200).json('Servicios vinculados')
     } catch (error) {
         res.status(400).json({ error: error.message })

--- a/Server/Routes/Routers/providersRouter.js
+++ b/Server/Routes/Routers/providersRouter.js
@@ -5,16 +5,18 @@ const deleteProviderById = require('../../Handlers/ProvidersHandlers/deleteProvi
 const loginProvider = require('../../Handlers/ProvidersHandlers/loginProvider')
 const getProviderById = require('./../../Handlers/ProvidersHandlers/getProviderById')
 const updateProvider = require('./../../Handlers/ProvidersHandlers/updateProvider')
+const updateOfferedServices = require('./../../Handlers/ProvidersHandlers/updateOfferedServices')
 
 const providersRouter = Router()
 
 providersRouter.get('/', getProviders)
-providersRouter.post('/login', loginProvider)
 providersRouter.get('/:id', getProviderById)
 
 providersRouter.put('/profile', updateProvider)
+providersRouter.put('/services', updateOfferedServices)
 
 providersRouter.post('/', postProvider)
+providersRouter.post('/login', loginProvider)
 
 providersRouter.delete('/:id', deleteProviderById)
 


### PR DESCRIPTION
Creación de la ruta /PUT /services, handler y controoller, para actualizar los providers, permite vincular servicios nuevos o actualizar servicios ya vinculados.